### PR TITLE
For phones with file-based encryption, use correct Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ accessed before the first unlock, the following modifications are needed.
 ```Java
 public class MyPreferenceProvider extends RemotePreferenceProvider {
     public MyPreferenceProvider() {
-        super("com.example.app.preferences", new RemotePreferenceFile[] {new RemotePreferenceFile()"main_prefs", true)});
+        super("com.example.app.preferences", new RemotePreferenceFile[]
+                {new RemotePreferenceFile("main_prefs", true)});
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Warning: when checking an operation such as `getAll()` or `clear()`,
 keys, make sure to also blacklist the `""` key as well!
 
 
-## Decrypted preferences
+## Device encrypted preferences
 
 By default, devices with Android N+ come with file-based encryption, which prevents
 RemotePreferences from accessing them before the first unlock after reboot. If preferences need to be
@@ -119,8 +119,9 @@ accessed before the first unlock, the following modifications are needed.
 ```Java
 public class MyPreferenceProvider extends RemotePreferenceProvider {
     public MyPreferenceProvider() {
-        super("com.example.app.preferences", new RemotePreferenceFile[]
-                {new RemotePreferenceFile("main_prefs", true)});
+        super("com.example.app.preferences", new RemotePreferenceFile[] {
+            new RemotePreferenceFile("main_prefs", true)
+        });
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,15 +19,37 @@ dependencies {
 
 2\. Subclass `RemotePreferenceProvider` and implement a 0-argument
 constructor which calls the super constructor with an authority
-(e.g. `"com.example.app.preferences"`) and an array of
-preference files to expose:
+(e.g. `"com.example.app.preferences"`) and a map of
+preference files (with modes: after unlock `Boolean.FALSE` and before unlock `Boolean.TRUE`) to expose:
 
 ```Java
 public class MyPreferenceProvider extends RemotePreferenceProvider {
     public MyPreferenceProvider() {
-        super("com.example.app.preferences", new String[] {"main_prefs"});
+        super("com.example.app.preferences", map("main_prefs", Boolean.TRUE));
     }
 }
+
+private static Map<String, Boolean> map(Object... values) {
+        if (values.length%2==1)
+            throw new IllegalArgumentException("Map must have even number of values");
+        Map<String, Boolean> hashMap = new HashMap<>(values.length/2);
+        String key;
+        Boolean value;
+        for(int i=0; i<values.length; i=i+2) {
+            try {
+                key = (String) values[i];
+            } catch (ClassCastException e) {
+                continue;
+            }
+            try {
+                value = (Boolean) values[i+1];
+            } catch (ClassCastException e) {
+                continue;
+            }
+            hashMap.put(key, value);
+        }
+        return hashMap;
+    }
 ```
 
 3\. Add the corresponding entry to `AndroidManifest.xml`, with
@@ -61,6 +83,8 @@ if your code is executing within the app that owns the preferences. Only use
 
 Also note that your preference keys cannot be `null` or `""` (empty string).
 
+Additionally, if you are trying to use any of these preferences before the user unlocks the phone,
+use `context = context.createDeviceProtectedStorageContext()`. This is an Android limitation (feature?)
 
 ## Security
 


### PR DESCRIPTION
Due to file-based encryption being introduced in Nougat, preferences are not available to be read into until the system is unlocked for the first time after each reboot. A workaround for this is to use Device Protected Storage (as opposed to Credential Protected Storage), also called as Direct Boot, which enables the preferences to be stored in decrypted format. 
https://github.com/rovo89/XposedBridge/issues/206
https://github.com/GravityBox/GravityBox/commit/d825b7be445c18de9a90eb8f77c1c5eb2b74deb8

Changes include:
- Constructor of the provider changed to use a map of file names and modes (device protected / credential protected) instead of an array of file names.
- Functions using `Context` in the provider changed to use the correct version of context, based on the mode passed previously.
- README.md updated to explain the change.